### PR TITLE
Fix time format in views.py

### DIFF
--- a/masterdata_checker/app/views.py
+++ b/masterdata_checker/app/views.py
@@ -66,7 +66,7 @@ def homepage(request):
 
                 log["timestamp"] = datetime.datetime.fromisoformat(
                     log["timestamp"].replace("Z", "+00:00")
-                ).strftime("%H:%M:%S, %d.%m-%Y")
+                ).strftime("%H:%M:%S, %d.%m.%Y")
 
                 context_log = {}
                 for k, v in log.items():


### PR DESCRIPTION
This pull request includes a minor change to the `homepage` function in the `masterdata_checker/app/views.py` file. The change fixes the date formatting in the `strftime` method by replacing the hyphen (`-`) between the month and year with a period (`.`).